### PR TITLE
feat: add PocketBase feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,5 +112,6 @@ When making changes to a feature, increment the `version` field in `devcontainer
 
 ## Current Features
 
-- **ffmpeg**: Installs ffmpeg with optional libvpx support
+- **ffmpeg**: Compiles and installs ffmpeg from source with configurable codecs
 - **git-absorb**: Installs git-absorb tool for automatic commit fixup
+- **pocketbase**: Installs PocketBase backend from official GitHub releases

--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ Installs [git-absorb](https://github.com/tummychow/git-absorb), a tool for autom
 }
 ```
 
+### pocketbase
+
+Installs [PocketBase](https://pocketbase.io/), an open-source backend in 1 file.
+
+```json
+"features": {
+    "ghcr.io/KevinBonnoron/features/pocketbase:0": {
+        "version": "0.29.3"
+    }
+}
+```
+
+Options:
+- `version`: PocketBase version to install (e.g., "0.29.3", "0.28.0"). Default: "0.29.3"
+
 ## Usage
 
 To use these features, add them to your `.devcontainer/devcontainer.json` file:

--- a/src/pocketbase/devcontainer-feature.json
+++ b/src/pocketbase/devcontainer-feature.json
@@ -1,0 +1,14 @@
+{
+  "id": "pocketbase",
+  "version": "0.0.1",
+  "name": "PocketBase",
+  "documentationURL": "https://github.com/KevinBonnoron/features/tree/main/src/pocketbase",
+  "description": "Install PocketBase - an open-source backend in 1 file.",
+  "options": {
+    "version": {
+      "type": "string",
+      "default": "0.29.3",
+      "description": "PocketBase version to install (e.g., '0.29.3', '0.28.0')"
+    }
+  }
+}

--- a/src/pocketbase/install.sh
+++ b/src/pocketbase/install.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -e
+
+VERSION="${version:-0.29.3}"
+
+echo "Installing PocketBase ${VERSION}..."
+
+# Detect architecture
+ARCH=$(uname -m)
+case $ARCH in
+    x86_64)
+        ARCH="amd64"
+        ;;
+    aarch64|arm64)
+        ARCH="arm64"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+# Detect OS
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+case $OS in
+    linux)
+        OS="linux"
+        ;;
+    darwin)
+        OS="darwin"
+        ;;
+    *)
+        echo "Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
+
+# Construct download URL
+FILENAME="pocketbase_${VERSION}_${OS}_${ARCH}.zip"
+URL="https://github.com/pocketbase/pocketbase/releases/download/v${VERSION}/${FILENAME}"
+
+# Install dependencies
+apt-get update
+apt-get install -y --no-install-recommends wget unzip ca-certificates
+
+# Download PocketBase
+cd /tmp
+echo "Downloading from ${URL}"
+wget -q "${URL}" -O pocketbase.zip
+
+# Extract
+echo "Extracting ${FILENAME}"
+unzip -q pocketbase.zip
+
+# Install to /usr/local/bin
+chmod +x pocketbase
+mv pocketbase /usr/local/bin/
+
+# Cleanup
+rm -f pocketbase.zip
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+
+echo "PocketBase ${VERSION} installed successfully at /usr/local/bin/pocketbase"

--- a/test/pocketbase/scenarios.json
+++ b/test/pocketbase/scenarios.json
@@ -1,0 +1,24 @@
+{
+  "default_version": {
+    "image": "ubuntu:22.04",
+    "features": {
+      "pocketbase": {}
+    }
+  },
+  "specific_version": {
+    "image": "ubuntu:22.04",
+    "features": {
+      "pocketbase": {
+        "version": "0.28.0"
+      }
+    }
+  },
+  "debian_latest": {
+    "image": "debian:12",
+    "features": {
+      "pocketbase": {
+        "version": "0.29.3"
+      }
+    }
+  }
+}

--- a/test/pocketbase/test.sh
+++ b/test/pocketbase/test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Import test library for `check` command
+source dev-container-features-test-lib
+
+# Check pocketbase is installed and working
+check "pocketbase is installed" pocketbase --version
+check "pocketbase command exists" which pocketbase
+
+# Verify pocketbase can show help
+check "pocketbase help works" pocketbase --help
+
+# Report results
+reportResults


### PR DESCRIPTION
Add PocketBase DevContainer feature that installs PocketBase from GitHub releases:
- Supports version configuration (default: 0.29.3)
- Auto-detects OS (Linux/Darwin) and architecture (amd64/arm64)
- Installs to /usr/local/bin/pocketbase
- Includes comprehensive tests with multiple scenarios
- Updated documentation in README.md and CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PocketBase backend installation feature with configurable version selection (default: 0.29.3) and multi-platform support

* **Documentation**
  * Documented the PocketBase feature, options, and usage
  * Updated ffmpeg feature description to indicate source compilation with configurable codecs

* **Tests**
  * Added test scenarios and a validation script to verify PocketBase installation and basic functionality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->